### PR TITLE
chore: update react peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19797,8 +19797,8 @@
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.4.2",
 				"@testing-library/react": "^14.3.1",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
+				"@types/react": "^19.0.10",
+				"@types/react-dom": "^19.0.4",
 				"@uberschrift/eslint-config": "*",
 				"@uberschrift/tsconfig": "*",
 				"eslint": "^8.57.0",
@@ -19812,7 +19812,7 @@
 				"vitest": "^1.5.0"
 			},
 			"peerDependencies": {
-				"react": "^18.2.0  || ^19.0"
+				"react": "^18.2 || ^19.0"
 			}
 		},
 		"packages/react/node_modules/@testing-library/jest-dom": {
@@ -19869,6 +19869,26 @@
 			"peer": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
+			}
+		},
+		"packages/react/node_modules/@types/react": {
+			"version": "19.0.10",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+			"integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.0.2"
+			}
+		},
+		"packages/react/node_modules/@types/react-dom": {
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
+			"integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.0.0"
 			}
 		},
 		"packages/react/node_modules/ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19816,7 +19816,7 @@
 			"peerDependencies": {
 				"@types/react": "*",
 				"@types/react-dom": "*",
-				"react": "^18.0 || ^19.0"
+				"react": "^18.2 || ^19.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5616,21 +5616,23 @@
 			"integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
 		},
 		"node_modules/@types/react": {
-			"version": "18.2.79",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
-			"integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
+			"version": "18.3.18",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+			"integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.2.25",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.25.tgz",
-			"integrity": "sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==",
+			"version": "18.3.5",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+			"integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
 			"dev": true,
-			"dependencies": {
-				"@types/react": "*"
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@types/react-transition-group": {
@@ -19797,8 +19799,8 @@
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.4.2",
 				"@testing-library/react": "^14.3.1",
-				"@types/react": "^19.0.10",
-				"@types/react-dom": "^19.0.4",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
 				"@uberschrift/eslint-config": "*",
 				"@uberschrift/tsconfig": "*",
 				"eslint": "^8.57.0",
@@ -19812,7 +19814,17 @@
 				"vitest": "^1.5.0"
 			},
 			"peerDependencies": {
-				"react": "^18.2 || ^19.0"
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^18.0 || ^19.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"packages/react/node_modules/@testing-library/jest-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 		},
 		"apps/docs": {
 			"name": "@uberschrift/docs",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"dependencies": {
 				"@remix-run/css-bundle": "^2.8.1",
 				"@remix-run/node": "^2.8.1",
@@ -310,7 +310,7 @@
 			}
 		},
 		"apps/nextjs-example": {
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"@tailwindcss/typography": "^0.5.12",
 				"next": "14.0.4",
@@ -341,7 +341,7 @@
 		},
 		"apps/react-vite-chakra-ui-example": {
 			"name": "@uberschrift/vite-chakra-ui-example",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"@chakra-ui/react": "^2.8.2",
 				"@emotion/react": "^11.11.4",
@@ -488,7 +488,7 @@
 		},
 		"apps/react-vite-example": {
 			"name": "@uberschrift/vite-example",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"@tailwindcss/typography": "^0.5.12",
 				"react": "^18.2.0",
@@ -634,7 +634,7 @@
 		},
 		"apps/react-vite-mui-example": {
 			"name": "@uberschrift/vite-mui-example",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"@emotion/react": "^11.11.4",
 				"@emotion/styled": "^11.11.5",
@@ -780,7 +780,7 @@
 			}
 		},
 		"apps/vue-vite-example": {
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"vue": "^3.4.24",
 				"vueberschrift": "*"
@@ -19778,7 +19778,7 @@
 		},
 		"packages/eslint-config": {
 			"name": "@uberschrift/eslint-config",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"devDependencies": {
 				"eslint-config-peerigon": "^37.2.0",
 				"eslint-plugin-jsx-a11y": "^6.8.0",
@@ -19792,7 +19792,7 @@
 		},
 		"packages/react": {
 			"name": "uberschrift",
-			"version": "1.1.12",
+			"version": "1.1.13",
 			"license": "UNLICENSED",
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.4.2",
@@ -19812,7 +19812,7 @@
 				"vitest": "^1.5.0"
 			},
 			"peerDependencies": {
-				"react": "^18.2.0"
+				"react": "^18.2.0  || ^19.0"
 			}
 		},
 		"packages/react/node_modules/@testing-library/jest-dom": {
@@ -20293,7 +20293,7 @@
 		},
 		"packages/vue": {
 			"name": "vueberschrift",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "UNLICENSED",
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.4.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,6 @@
 		"vitest": "^1.5.0"
 	},
 	"peerDependencies": {
-		"react": "^18.2.0"
+		"react": "^18.2  || ^19.0"
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
 		"vitest": "^1.5.0"
 	},
 	"peerDependencies": {
-		"react": "^18.2 || ^19.0",
+		"react": ">=18.0.0",
 		"@types/react": "*",
 		"@types/react-dom": "*"
 	},

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,8 +33,8 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.4.2",
 		"@testing-library/react": "^14.3.1",
-		"@types/react": "^19.0.10",
-		"@types/react-dom": "^19.0.4",
+		"@types/react": "^18.2.79",
+		"@types/react-dom": "^18.2.25",
 		"@uberschrift/eslint-config": "*",
 		"@uberschrift/tsconfig": "*",
 		"eslint": "^8.57.0",
@@ -48,6 +48,16 @@
 		"vitest": "^1.5.0"
 	},
 	"peerDependencies": {
-		"react": "^18.2 || ^19.0"
+		"react": "^18.2 || ^19.0",
+		"@types/react": "*",
+		"@types/react-dom": "*"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		},
+		"@types/react-dom": {
+			"optional": true
+		}
 	}
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,8 +33,8 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.4.2",
 		"@testing-library/react": "^14.3.1",
-		"@types/react": "^18.2.79",
-		"@types/react-dom": "^18.2.25",
+		"@types/react": "^19.0.10",
+		"@types/react-dom": "^19.0.4",
 		"@uberschrift/eslint-config": "*",
 		"@uberschrift/tsconfig": "*",
 		"eslint": "^8.57.0",
@@ -48,6 +48,6 @@
 		"vitest": "^1.5.0"
 	},
 	"peerDependencies": {
-		"react": "^18.2  || ^19.0"
+		"react": "^18.2 || ^19.0"
 	}
 }


### PR DESCRIPTION
We want to use uberschrift in a project that uses React 19. Currently, the react package uses React 18 as a peer dependency. There shouldn't be a problem with allowing React 19 as well though. 